### PR TITLE
Add OGRE plugins directory to rviz and librviz.so installed RUNPATH

### DIFF
--- a/src/rviz/CMakeLists.txt
+++ b/src/rviz/CMakeLists.txt
@@ -133,7 +133,10 @@ add_library(${PROJECT_NAME}
 )
 
 if(NOT WIN32)
-  set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-std=c++11")
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    COMPILE_FLAGS "-std=c++11"
+    INSTALL_RPATH "${OGRE_PLUGIN_PATH}"
+    )
 endif()
 
 target_link_libraries(${PROJECT_NAME}
@@ -159,7 +162,10 @@ endif(APPLE)
 add_executable(executable main.cpp)
 
 if(NOT WIN32)
-  set_target_properties(executable PROPERTIES COMPILE_FLAGS "-std=c++11")
+  set_target_properties(executable PROPERTIES
+    COMPILE_FLAGS "-std=c++11"
+    INSTALL_RPATH "${OGRE_PLUGIN_PATH}"
+    )
 endif()
 
 target_link_libraries(executable ${PROJECT_NAME} ${QT_LIBRARIES} ${OGRE_OV_LIBRARIES_ABS})


### PR DESCRIPTION
Fixes error where `ld-linux.so` can't find OGRE `RenderSystem_GL` plugin when running installed `rviz`.

```
process[robot_ui-3]: started with pid [2765]
Traceback (most recent call last):
  File "[...]/robot_ui/scripts/robot_ui", line 16, in <module>
    import rviz
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rviz/__init__.py", line 27, in <module>
    import librviz_sip
ImportError: RenderSystem_GL.so.1.9.0: cannot open shared object file: No such file or directory
================================================================================REQUIRED process [robot_ui-3] has died!
process has died [pid 2765, exit code 1, cmd [...]/robot_ui/scripts/robot_ui __name:=robot_ui __log:=[...]/.ros/log/42f1e7f0-0409-11e9-bc77-58946ba81914/robot_ui-3.log].
log file: [...]/.ros/log/42f1e7f0-0409-11e9-bc77-58946ba81914/robot_ui-3*.log
Initiating shutdown!
================================================================================
[robot_ui-3] killing on exit
```